### PR TITLE
Resolves issue #74 - implement "2x" images on retina devices

### DIFF
--- a/Source/Models/Comic/Comic.m
+++ b/Source/Models/Comic/Comic.m
@@ -37,6 +37,11 @@
     self.isInteractive = [dictionary[kIsInteractiveKey] boolValue];
     self.explainURLString = [NSString stringWithFormat:@"%@/%@", kExplainURLBase, @(self.num)];
 
+    if ((UIScreen.mainScreen.scale >= 2) && (self.comicID.integerValue >= 1084)) {
+        NSString *patchingImageString = [self.imageURLString stringByDeletingPathExtension];
+        self.imageURLString = [patchingImageString stringByAppendingString:@"_2x.png"];
+    }
+    
     NSInteger day = [self.day integerValue];
     NSInteger month = [self.month integerValue];
     NSInteger year = [self.year integerValue];


### PR DESCRIPTION
To appropriately implement "retina" images, the device screen scale is checked. #74 mentions `1084` being the first supported comic. If both these conditions are met, the string representing the URL is modified. Another option for the string manipulation is 

```obj
        NSString *patchingImageString = [self.imageURLString stringByDeletingPathExtension];
        patchingImageString = [patchingImageString stringByAppendingString:@"_2x"]
        self.imageURLString = [patchingImageString stringByAppendingPathExtension:@"png"];
```

The above approach is more clear, however I felt that the performance trade-offs were not worth using it.